### PR TITLE
Wrap url in `'`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ fn handler(selection: Match, config: &Config) -> HandleResult {
     if let Err(why) = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "xdg-open https://{}",
+            "xdg-open 'https://{}'",
             engine
                 .value()
                 .replace("{}", &encode(&selection.title.to_string()))


### PR DESCRIPTION
### This fixes the problem that bash escapes the url string.

Wrap url with `'`. → Internal command: xdg-open 'url'

#### Why the wrap?
Example: 
We want to search for packages (eg: anyrun) in the aur that are not outdated (url: https://aur.archlinux.org/packages?K=anyrun&outdated=off)

user input: `anyrun`
resulting internal string: `https://aur.archlinux.org/packages?K=anyrun&outdated=off`
resulting internal command: `xdg-open https://aur.archlinux.org/packages?K=anyrun&outdated=off`

running in bash: 
```bash
xdg-open https://aur.archlinux.org/packages?K=anyrun&outdated=off
```
we see that the pages opens but  `&...` disappeared. 
Wrapping the url fixes this:
 ```bash
xdg-open 'https://aur.archlinux.org/packages?K=anyrun&outdated=off'
```
Fixes #1 